### PR TITLE
Add gradle 8+ support

### DIFF
--- a/flutter_avif/pubspec.yaml
+++ b/flutter_avif/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_avif
 description: A flutter plugin to view and encode avif images using libavif.
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/yekeskin/flutter_avif
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_avif_platform_interface: ^2.0.0
-  flutter_avif_android: ^2.0.0
+  flutter_avif_android: ^2.0.1
   flutter_avif_ios: ^2.0.0
   flutter_avif_macos: ^2.0.0
   flutter_avif_linux: ^2.0.0

--- a/flutter_avif_android/android/build.gradle
+++ b/flutter_avif_android/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.2'
     }
 }
 
@@ -22,11 +22,16 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+
+    if (project.android.hasProperty("namespace")) {
+        namespace = "com.teknorota.flutter_avif"
+    }
+
     compileSdkVersion 31
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     defaultConfig {

--- a/flutter_avif_android/pubspec.yaml
+++ b/flutter_avif_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_avif_android
 description: Android implementation for flutter_avif.
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/yekeskin/flutter_avif/tree/main/flutter_avif_android
 
 environment:


### PR DESCRIPTION
Hello, @yekeskin. This PR provides gradle 8+ support and fixes the namespace error on build if Flutter app has been migrated to Gradle 8+. Could you please look into this?