### PR TITLE
Upgrade protobuf dependency

### DIFF
--- a/flutter_avif_platform_interface/lib/models/avif_info.pb.dart
+++ b/flutter_avif_platform_interface/lib/models/avif_info.pb.dart
@@ -1,17 +1,20 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: avif_info.proto
-//
-// @dart = 2.12
+// Generated from avif_info.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 class AvifInfo extends $pb.GeneratedMessage {
   factory AvifInfo({
@@ -20,91 +23,89 @@ class AvifInfo extends $pb.GeneratedMessage {
     $core.int? imageCount,
     $core.double? duration,
   }) {
-    final $result = create();
-    if (width != null) {
-      $result.width = width;
-    }
-    if (height != null) {
-      $result.height = height;
-    }
-    if (imageCount != null) {
-      $result.imageCount = imageCount;
-    }
-    if (duration != null) {
-      $result.duration = duration;
-    }
-    return $result;
+    final result = create();
+    if (width != null) result.width = width;
+    if (height != null) result.height = height;
+    if (imageCount != null) result.imageCount = imageCount;
+    if (duration != null) result.duration = duration;
+    return result;
   }
-  AvifInfo._() : super();
-  factory AvifInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AvifInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AvifInfo', package: const $pb.PackageName(_omitMessageNames ? '' : 'models'), createEmptyInstance: create)
-    ..a<$core.int>(1, _omitFieldNames ? '' : 'width', $pb.PbFieldType.OU3)
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'height', $pb.PbFieldType.OU3)
-    ..a<$core.int>(3, _omitFieldNames ? '' : 'imageCount', $pb.PbFieldType.OU3)
-    ..a<$core.double>(4, _omitFieldNames ? '' : 'duration', $pb.PbFieldType.OD)
-    ..hasRequiredFields = false
-  ;
+  AvifInfo._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  AvifInfo clone() => AvifInfo()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AvifInfo copyWith(void Function(AvifInfo) updates) => super.copyWith((message) => updates(message as AvifInfo)) as AvifInfo;
+  factory AvifInfo.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory AvifInfo.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
 
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'AvifInfo',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'models'),
+      createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'width', fieldType: $pb.PbFieldType.OU3)
+    ..aI(2, _omitFieldNames ? '' : 'height', fieldType: $pb.PbFieldType.OU3)
+    ..aI(3, _omitFieldNames ? '' : 'imageCount', fieldType: $pb.PbFieldType.OU3)
+    ..aD(4, _omitFieldNames ? '' : 'duration')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AvifInfo clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  AvifInfo copyWith(void Function(AvifInfo) updates) =>
+      super.copyWith((message) => updates(message as AvifInfo)) as AvifInfo;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static AvifInfo create() => AvifInfo._();
+  @$core.override
   AvifInfo createEmptyInstance() => create();
-  static $pb.PbList<AvifInfo> createRepeated() => $pb.PbList<AvifInfo>();
   @$core.pragma('dart2js:noInline')
-  static AvifInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AvifInfo>(create);
+  static AvifInfo getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AvifInfo>(create);
   static AvifInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get width => $_getIZ(0);
   @$pb.TagNumber(1)
-  set width($core.int v) { $_setUnsignedInt32(0, v); }
+  set width($core.int value) => $_setUnsignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasWidth() => $_has(0);
   @$pb.TagNumber(1)
-  void clearWidth() => clearField(1);
+  void clearWidth() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.int get height => $_getIZ(1);
   @$pb.TagNumber(2)
-  set height($core.int v) { $_setUnsignedInt32(1, v); }
+  set height($core.int value) => $_setUnsignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasHeight() => $_has(1);
   @$pb.TagNumber(2)
-  void clearHeight() => clearField(2);
+  void clearHeight() => $_clearField(2);
 
   @$pb.TagNumber(3)
   $core.int get imageCount => $_getIZ(2);
   @$pb.TagNumber(3)
-  set imageCount($core.int v) { $_setUnsignedInt32(2, v); }
+  set imageCount($core.int value) => $_setUnsignedInt32(2, value);
   @$pb.TagNumber(3)
   $core.bool hasImageCount() => $_has(2);
   @$pb.TagNumber(3)
-  void clearImageCount() => clearField(3);
+  void clearImageCount() => $_clearField(3);
 
   @$pb.TagNumber(4)
   $core.double get duration => $_getN(3);
   @$pb.TagNumber(4)
-  set duration($core.double v) { $_setDouble(3, v); }
+  set duration($core.double value) => $_setDouble(3, value);
   @$pb.TagNumber(4)
   $core.bool hasDuration() => $_has(3);
   @$pb.TagNumber(4)
-  void clearDuration() => clearField(4);
+  void clearDuration() => $_clearField(4);
 }
 
-
-const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter_avif_platform_interface/lib/models/avif_info.pbenum.dart
+++ b/flutter_avif_platform_interface/lib/models/avif_info.pbenum.dart
@@ -1,0 +1,11 @@
+// This is a generated file - do not edit.
+//
+// Generated from avif_info.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/flutter_avif_platform_interface/lib/models/avif_info.pbjson.dart
+++ b/flutter_avif_platform_interface/lib/models/avif_info.pbjson.dart
@@ -1,0 +1,33 @@
+// This is a generated file - do not edit.
+//
+// Generated from avif_info.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use avifInfoDescriptor instead')
+const AvifInfo$json = {
+  '1': 'AvifInfo',
+  '2': [
+    {'1': 'width', '3': 1, '4': 1, '5': 13, '10': 'width'},
+    {'1': 'height', '3': 2, '4': 1, '5': 13, '10': 'height'},
+    {'1': 'image_count', '3': 3, '4': 1, '5': 13, '10': 'imageCount'},
+    {'1': 'duration', '3': 4, '4': 1, '5': 1, '10': 'duration'},
+  ],
+};
+
+/// Descriptor for `AvifInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List avifInfoDescriptor = $convert.base64Decode(
+    'CghBdmlmSW5mbxIUCgV3aWR0aBgBIAEoDVIFd2lkdGgSFgoGaGVpZ2h0GAIgASgNUgZoZWlnaH'
+    'QSHwoLaW1hZ2VfY291bnQYAyABKA1SCmltYWdlQ291bnQSGgoIZHVyYXRpb24YBCABKAFSCGR1'
+    'cmF0aW9u');

--- a/flutter_avif_platform_interface/lib/models/encode_frame.pb.dart
+++ b/flutter_avif_platform_interface/lib/models/encode_frame.pb.dart
@@ -1,82 +1,91 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: encode_frame.proto
-//
-// @dart = 2.12
+// Generated from encode_frame.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 class EncodeFrame extends $pb.GeneratedMessage {
   factory EncodeFrame({
     $core.List<$core.int>? data,
     $core.int? durationInTimescale,
   }) {
-    final $result = create();
-    if (data != null) {
-      $result.data = data;
-    }
-    if (durationInTimescale != null) {
-      $result.durationInTimescale = durationInTimescale;
-    }
-    return $result;
+    final result = create();
+    if (data != null) result.data = data;
+    if (durationInTimescale != null)
+      result.durationInTimescale = durationInTimescale;
+    return result;
   }
-  EncodeFrame._() : super();
-  factory EncodeFrame.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory EncodeFrame.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncodeFrame', package: const $pb.PackageName(_omitMessageNames ? '' : 'models'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'durationInTimescale', $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false
-  ;
+  EncodeFrame._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  EncodeFrame clone() => EncodeFrame()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  EncodeFrame copyWith(void Function(EncodeFrame) updates) => super.copyWith((message) => updates(message as EncodeFrame)) as EncodeFrame;
+  factory EncodeFrame.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory EncodeFrame.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
 
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'EncodeFrame',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'models'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..aI(2, _omitFieldNames ? '' : 'durationInTimescale',
+        fieldType: $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  EncodeFrame clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  EncodeFrame copyWith(void Function(EncodeFrame) updates) =>
+      super.copyWith((message) => updates(message as EncodeFrame))
+          as EncodeFrame;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EncodeFrame create() => EncodeFrame._();
+  @$core.override
   EncodeFrame createEmptyInstance() => create();
-  static $pb.PbList<EncodeFrame> createRepeated() => $pb.PbList<EncodeFrame>();
   @$core.pragma('dart2js:noInline')
-  static EncodeFrame getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncodeFrame>(create);
+  static EncodeFrame getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<EncodeFrame>(create);
   static EncodeFrame? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get data => $_getN(0);
   @$pb.TagNumber(1)
-  set data($core.List<$core.int> v) { $_setBytes(0, v); }
+  set data($core.List<$core.int> value) => $_setBytes(0, value);
   @$pb.TagNumber(1)
   $core.bool hasData() => $_has(0);
   @$pb.TagNumber(1)
-  void clearData() => clearField(1);
+  void clearData() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.int get durationInTimescale => $_getIZ(1);
   @$pb.TagNumber(2)
-  set durationInTimescale($core.int v) { $_setUnsignedInt32(1, v); }
+  set durationInTimescale($core.int value) => $_setUnsignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasDurationInTimescale() => $_has(1);
   @$pb.TagNumber(2)
-  void clearDurationInTimescale() => clearField(2);
+  void clearDurationInTimescale() => $_clearField(2);
 }
 
-
-const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter_avif_platform_interface/lib/models/encode_frame.pbenum.dart
+++ b/flutter_avif_platform_interface/lib/models/encode_frame.pbenum.dart
@@ -1,0 +1,11 @@
+// This is a generated file - do not edit.
+//
+// Generated from encode_frame.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/flutter_avif_platform_interface/lib/models/encode_frame.pbjson.dart
+++ b/flutter_avif_platform_interface/lib/models/encode_frame.pbjson.dart
@@ -1,0 +1,36 @@
+// This is a generated file - do not edit.
+//
+// Generated from encode_frame.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use encodeFrameDescriptor instead')
+const EncodeFrame$json = {
+  '1': 'EncodeFrame',
+  '2': [
+    {'1': 'data', '3': 1, '4': 1, '5': 12, '10': 'data'},
+    {
+      '1': 'duration_in_timescale',
+      '3': 2,
+      '4': 1,
+      '5': 13,
+      '10': 'durationInTimescale'
+    },
+  ],
+};
+
+/// Descriptor for `EncodeFrame`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List encodeFrameDescriptor = $convert.base64Decode(
+    'CgtFbmNvZGVGcmFtZRISCgRkYXRhGAEgASgMUgRkYXRhEjIKFWR1cmF0aW9uX2luX3RpbWVzY2'
+    'FsZRgCIAEoDVITZHVyYXRpb25JblRpbWVzY2FsZQ==');

--- a/flutter_avif_platform_interface/lib/models/encode_request.pb.dart
+++ b/flutter_avif_platform_interface/lib/models/encode_request.pb.dart
@@ -1,19 +1,22 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: encode_request.proto
-//
-// @dart = 2.12
+// Generated from encode_request.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import 'encode_frame.pb.dart' as $0;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 class EncodeRequest extends $pb.GeneratedMessage {
   factory EncodeRequest({
@@ -29,176 +32,167 @@ class EncodeRequest extends $pb.GeneratedMessage {
     $core.Iterable<$0.EncodeFrame>? imageList,
     $core.List<$core.int>? exifData,
   }) {
-    final $result = create();
-    if (width != null) {
-      $result.width = width;
-    }
-    if (height != null) {
-      $result.height = height;
-    }
-    if (speed != null) {
-      $result.speed = speed;
-    }
-    if (maxThreads != null) {
-      $result.maxThreads = maxThreads;
-    }
-    if (timescale != null) {
-      $result.timescale = timescale;
-    }
-    if (maxQuantizer != null) {
-      $result.maxQuantizer = maxQuantizer;
-    }
-    if (minQuantizer != null) {
-      $result.minQuantizer = minQuantizer;
-    }
-    if (maxQuantizerAlpha != null) {
-      $result.maxQuantizerAlpha = maxQuantizerAlpha;
-    }
-    if (minQuantizerAlpha != null) {
-      $result.minQuantizerAlpha = minQuantizerAlpha;
-    }
-    if (imageList != null) {
-      $result.imageList.addAll(imageList);
-    }
-    if (exifData != null) {
-      $result.exifData = exifData;
-    }
-    return $result;
+    final result = create();
+    if (width != null) result.width = width;
+    if (height != null) result.height = height;
+    if (speed != null) result.speed = speed;
+    if (maxThreads != null) result.maxThreads = maxThreads;
+    if (timescale != null) result.timescale = timescale;
+    if (maxQuantizer != null) result.maxQuantizer = maxQuantizer;
+    if (minQuantizer != null) result.minQuantizer = minQuantizer;
+    if (maxQuantizerAlpha != null) result.maxQuantizerAlpha = maxQuantizerAlpha;
+    if (minQuantizerAlpha != null) result.minQuantizerAlpha = minQuantizerAlpha;
+    if (imageList != null) result.imageList.addAll(imageList);
+    if (exifData != null) result.exifData = exifData;
+    return result;
   }
-  EncodeRequest._() : super();
-  factory EncodeRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory EncodeRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'EncodeRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'models'), createEmptyInstance: create)
-    ..a<$core.int>(1, _omitFieldNames ? '' : 'width', $pb.PbFieldType.OU3)
-    ..a<$core.int>(2, _omitFieldNames ? '' : 'height', $pb.PbFieldType.OU3)
-    ..a<$core.int>(3, _omitFieldNames ? '' : 'speed', $pb.PbFieldType.OS3)
-    ..a<$core.int>(4, _omitFieldNames ? '' : 'maxThreads', $pb.PbFieldType.OS3)
-    ..a<$core.int>(5, _omitFieldNames ? '' : 'timescale', $pb.PbFieldType.OU3)
-    ..a<$core.int>(6, _omitFieldNames ? '' : 'maxQuantizer', $pb.PbFieldType.OS3)
-    ..a<$core.int>(7, _omitFieldNames ? '' : 'minQuantizer', $pb.PbFieldType.OS3)
-    ..a<$core.int>(8, _omitFieldNames ? '' : 'maxQuantizerAlpha', $pb.PbFieldType.OS3)
-    ..a<$core.int>(9, _omitFieldNames ? '' : 'minQuantizerAlpha', $pb.PbFieldType.OS3)
-    ..pc<$0.EncodeFrame>(10, _omitFieldNames ? '' : 'imageList', $pb.PbFieldType.PM, subBuilder: $0.EncodeFrame.create)
-    ..a<$core.List<$core.int>>(11, _omitFieldNames ? '' : 'exifData', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+  EncodeRequest._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  EncodeRequest clone() => EncodeRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  EncodeRequest copyWith(void Function(EncodeRequest) updates) => super.copyWith((message) => updates(message as EncodeRequest)) as EncodeRequest;
+  factory EncodeRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory EncodeRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
 
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'EncodeRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'models'),
+      createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'width', fieldType: $pb.PbFieldType.OU3)
+    ..aI(2, _omitFieldNames ? '' : 'height', fieldType: $pb.PbFieldType.OU3)
+    ..aI(3, _omitFieldNames ? '' : 'speed', fieldType: $pb.PbFieldType.OS3)
+    ..aI(4, _omitFieldNames ? '' : 'maxThreads', fieldType: $pb.PbFieldType.OS3)
+    ..aI(5, _omitFieldNames ? '' : 'timescale', fieldType: $pb.PbFieldType.OU3)
+    ..aI(6, _omitFieldNames ? '' : 'maxQuantizer',
+        fieldType: $pb.PbFieldType.OS3)
+    ..aI(7, _omitFieldNames ? '' : 'minQuantizer',
+        fieldType: $pb.PbFieldType.OS3)
+    ..aI(8, _omitFieldNames ? '' : 'maxQuantizerAlpha',
+        fieldType: $pb.PbFieldType.OS3)
+    ..aI(9, _omitFieldNames ? '' : 'minQuantizerAlpha',
+        fieldType: $pb.PbFieldType.OS3)
+    ..pPM<$0.EncodeFrame>(10, _omitFieldNames ? '' : 'imageList',
+        subBuilder: $0.EncodeFrame.create)
+    ..a<$core.List<$core.int>>(
+        11, _omitFieldNames ? '' : 'exifData', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  EncodeRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  EncodeRequest copyWith(void Function(EncodeRequest) updates) =>
+      super.copyWith((message) => updates(message as EncodeRequest))
+          as EncodeRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static EncodeRequest create() => EncodeRequest._();
+  @$core.override
   EncodeRequest createEmptyInstance() => create();
-  static $pb.PbList<EncodeRequest> createRepeated() => $pb.PbList<EncodeRequest>();
   @$core.pragma('dart2js:noInline')
-  static EncodeRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<EncodeRequest>(create);
+  static EncodeRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<EncodeRequest>(create);
   static EncodeRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get width => $_getIZ(0);
   @$pb.TagNumber(1)
-  set width($core.int v) { $_setUnsignedInt32(0, v); }
+  set width($core.int value) => $_setUnsignedInt32(0, value);
   @$pb.TagNumber(1)
   $core.bool hasWidth() => $_has(0);
   @$pb.TagNumber(1)
-  void clearWidth() => clearField(1);
+  void clearWidth() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.int get height => $_getIZ(1);
   @$pb.TagNumber(2)
-  set height($core.int v) { $_setUnsignedInt32(1, v); }
+  set height($core.int value) => $_setUnsignedInt32(1, value);
   @$pb.TagNumber(2)
   $core.bool hasHeight() => $_has(1);
   @$pb.TagNumber(2)
-  void clearHeight() => clearField(2);
+  void clearHeight() => $_clearField(2);
 
   @$pb.TagNumber(3)
   $core.int get speed => $_getIZ(2);
   @$pb.TagNumber(3)
-  set speed($core.int v) { $_setSignedInt32(2, v); }
+  set speed($core.int value) => $_setSignedInt32(2, value);
   @$pb.TagNumber(3)
   $core.bool hasSpeed() => $_has(2);
   @$pb.TagNumber(3)
-  void clearSpeed() => clearField(3);
+  void clearSpeed() => $_clearField(3);
 
   @$pb.TagNumber(4)
   $core.int get maxThreads => $_getIZ(3);
   @$pb.TagNumber(4)
-  set maxThreads($core.int v) { $_setSignedInt32(3, v); }
+  set maxThreads($core.int value) => $_setSignedInt32(3, value);
   @$pb.TagNumber(4)
   $core.bool hasMaxThreads() => $_has(3);
   @$pb.TagNumber(4)
-  void clearMaxThreads() => clearField(4);
+  void clearMaxThreads() => $_clearField(4);
 
   @$pb.TagNumber(5)
   $core.int get timescale => $_getIZ(4);
   @$pb.TagNumber(5)
-  set timescale($core.int v) { $_setUnsignedInt32(4, v); }
+  set timescale($core.int value) => $_setUnsignedInt32(4, value);
   @$pb.TagNumber(5)
   $core.bool hasTimescale() => $_has(4);
   @$pb.TagNumber(5)
-  void clearTimescale() => clearField(5);
+  void clearTimescale() => $_clearField(5);
 
   @$pb.TagNumber(6)
   $core.int get maxQuantizer => $_getIZ(5);
   @$pb.TagNumber(6)
-  set maxQuantizer($core.int v) { $_setSignedInt32(5, v); }
+  set maxQuantizer($core.int value) => $_setSignedInt32(5, value);
   @$pb.TagNumber(6)
   $core.bool hasMaxQuantizer() => $_has(5);
   @$pb.TagNumber(6)
-  void clearMaxQuantizer() => clearField(6);
+  void clearMaxQuantizer() => $_clearField(6);
 
   @$pb.TagNumber(7)
   $core.int get minQuantizer => $_getIZ(6);
   @$pb.TagNumber(7)
-  set minQuantizer($core.int v) { $_setSignedInt32(6, v); }
+  set minQuantizer($core.int value) => $_setSignedInt32(6, value);
   @$pb.TagNumber(7)
   $core.bool hasMinQuantizer() => $_has(6);
   @$pb.TagNumber(7)
-  void clearMinQuantizer() => clearField(7);
+  void clearMinQuantizer() => $_clearField(7);
 
   @$pb.TagNumber(8)
   $core.int get maxQuantizerAlpha => $_getIZ(7);
   @$pb.TagNumber(8)
-  set maxQuantizerAlpha($core.int v) { $_setSignedInt32(7, v); }
+  set maxQuantizerAlpha($core.int value) => $_setSignedInt32(7, value);
   @$pb.TagNumber(8)
   $core.bool hasMaxQuantizerAlpha() => $_has(7);
   @$pb.TagNumber(8)
-  void clearMaxQuantizerAlpha() => clearField(8);
+  void clearMaxQuantizerAlpha() => $_clearField(8);
 
   @$pb.TagNumber(9)
   $core.int get minQuantizerAlpha => $_getIZ(8);
   @$pb.TagNumber(9)
-  set minQuantizerAlpha($core.int v) { $_setSignedInt32(8, v); }
+  set minQuantizerAlpha($core.int value) => $_setSignedInt32(8, value);
   @$pb.TagNumber(9)
   $core.bool hasMinQuantizerAlpha() => $_has(8);
   @$pb.TagNumber(9)
-  void clearMinQuantizerAlpha() => clearField(9);
+  void clearMinQuantizerAlpha() => $_clearField(9);
 
   @$pb.TagNumber(10)
-  $core.List<$0.EncodeFrame> get imageList => $_getList(9);
+  $pb.PbList<$0.EncodeFrame> get imageList => $_getList(9);
 
   @$pb.TagNumber(11)
   $core.List<$core.int> get exifData => $_getN(10);
   @$pb.TagNumber(11)
-  set exifData($core.List<$core.int> v) { $_setBytes(10, v); }
+  set exifData($core.List<$core.int> value) => $_setBytes(10, value);
   @$pb.TagNumber(11)
   $core.bool hasExifData() => $_has(10);
   @$pb.TagNumber(11)
-  void clearExifData() => clearField(11);
+  void clearExifData() => $_clearField(11);
 }
 
-
-const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter_avif_platform_interface/lib/models/encode_request.pbenum.dart
+++ b/flutter_avif_platform_interface/lib/models/encode_request.pbenum.dart
@@ -1,0 +1,11 @@
+// This is a generated file - do not edit.
+//
+// Generated from encode_request.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/flutter_avif_platform_interface/lib/models/encode_request.pbjson.dart
+++ b/flutter_avif_platform_interface/lib/models/encode_request.pbjson.dart
@@ -1,0 +1,64 @@
+// This is a generated file - do not edit.
+//
+// Generated from encode_request.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use encodeRequestDescriptor instead')
+const EncodeRequest$json = {
+  '1': 'EncodeRequest',
+  '2': [
+    {'1': 'width', '3': 1, '4': 1, '5': 13, '10': 'width'},
+    {'1': 'height', '3': 2, '4': 1, '5': 13, '10': 'height'},
+    {'1': 'speed', '3': 3, '4': 1, '5': 17, '10': 'speed'},
+    {'1': 'max_threads', '3': 4, '4': 1, '5': 17, '10': 'maxThreads'},
+    {'1': 'timescale', '3': 5, '4': 1, '5': 13, '10': 'timescale'},
+    {'1': 'max_quantizer', '3': 6, '4': 1, '5': 17, '10': 'maxQuantizer'},
+    {'1': 'min_quantizer', '3': 7, '4': 1, '5': 17, '10': 'minQuantizer'},
+    {
+      '1': 'max_quantizer_alpha',
+      '3': 8,
+      '4': 1,
+      '5': 17,
+      '10': 'maxQuantizerAlpha'
+    },
+    {
+      '1': 'min_quantizer_alpha',
+      '3': 9,
+      '4': 1,
+      '5': 17,
+      '10': 'minQuantizerAlpha'
+    },
+    {
+      '1': 'image_list',
+      '3': 10,
+      '4': 3,
+      '5': 11,
+      '6': '.models.EncodeFrame',
+      '10': 'imageList'
+    },
+    {'1': 'exif_data', '3': 11, '4': 1, '5': 12, '10': 'exifData'},
+  ],
+};
+
+/// Descriptor for `EncodeRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List encodeRequestDescriptor = $convert.base64Decode(
+    'Cg1FbmNvZGVSZXF1ZXN0EhQKBXdpZHRoGAEgASgNUgV3aWR0aBIWCgZoZWlnaHQYAiABKA1SBm'
+    'hlaWdodBIUCgVzcGVlZBgDIAEoEVIFc3BlZWQSHwoLbWF4X3RocmVhZHMYBCABKBFSCm1heFRo'
+    'cmVhZHMSHAoJdGltZXNjYWxlGAUgASgNUgl0aW1lc2NhbGUSIwoNbWF4X3F1YW50aXplchgGIA'
+    'EoEVIMbWF4UXVhbnRpemVyEiMKDW1pbl9xdWFudGl6ZXIYByABKBFSDG1pblF1YW50aXplchIu'
+    'ChNtYXhfcXVhbnRpemVyX2FscGhhGAggASgRUhFtYXhRdWFudGl6ZXJBbHBoYRIuChNtaW5fcX'
+    'VhbnRpemVyX2FscGhhGAkgASgRUhFtaW5RdWFudGl6ZXJBbHBoYRIyCgppbWFnZV9saXN0GAog'
+    'AygLMhMubW9kZWxzLkVuY29kZUZyYW1lUglpbWFnZUxpc3QSGwoJZXhpZl9kYXRhGAsgASgMUg'
+    'hleGlmRGF0YQ==');

--- a/flutter_avif_platform_interface/lib/models/frame.pb.dart
+++ b/flutter_avif_platform_interface/lib/models/frame.pb.dart
@@ -1,17 +1,20 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: frame.proto
-//
-// @dart = 2.12
+// Generated from frame.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 class Frame extends $pb.GeneratedMessage {
   factory Frame({
@@ -20,91 +23,90 @@ class Frame extends $pb.GeneratedMessage {
     $core.int? width,
     $core.int? height,
   }) {
-    final $result = create();
-    if (data != null) {
-      $result.data = data;
-    }
-    if (duration != null) {
-      $result.duration = duration;
-    }
-    if (width != null) {
-      $result.width = width;
-    }
-    if (height != null) {
-      $result.height = height;
-    }
-    return $result;
+    final result = create();
+    if (data != null) result.data = data;
+    if (duration != null) result.duration = duration;
+    if (width != null) result.width = width;
+    if (height != null) result.height = height;
+    return result;
   }
-  Frame._() : super();
-  factory Frame.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Frame.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Frame', package: const $pb.PackageName(_omitMessageNames ? '' : 'models'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
-    ..a<$core.double>(2, _omitFieldNames ? '' : 'duration', $pb.PbFieldType.OD)
-    ..a<$core.int>(3, _omitFieldNames ? '' : 'width', $pb.PbFieldType.OU3)
-    ..a<$core.int>(4, _omitFieldNames ? '' : 'height', $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false
-  ;
+  Frame._();
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  Frame clone() => Frame()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Frame copyWith(void Function(Frame) updates) => super.copyWith((message) => updates(message as Frame)) as Frame;
+  factory Frame.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory Frame.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
 
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Frame',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'models'),
+      createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(
+        1, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..aD(2, _omitFieldNames ? '' : 'duration')
+    ..aI(3, _omitFieldNames ? '' : 'width', fieldType: $pb.PbFieldType.OU3)
+    ..aI(4, _omitFieldNames ? '' : 'height', fieldType: $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Frame clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  Frame copyWith(void Function(Frame) updates) =>
+      super.copyWith((message) => updates(message as Frame)) as Frame;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static Frame create() => Frame._();
+  @$core.override
   Frame createEmptyInstance() => create();
-  static $pb.PbList<Frame> createRepeated() => $pb.PbList<Frame>();
   @$core.pragma('dart2js:noInline')
-  static Frame getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Frame>(create);
+  static Frame getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Frame>(create);
   static Frame? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get data => $_getN(0);
   @$pb.TagNumber(1)
-  set data($core.List<$core.int> v) { $_setBytes(0, v); }
+  set data($core.List<$core.int> value) => $_setBytes(0, value);
   @$pb.TagNumber(1)
   $core.bool hasData() => $_has(0);
   @$pb.TagNumber(1)
-  void clearData() => clearField(1);
+  void clearData() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.double get duration => $_getN(1);
   @$pb.TagNumber(2)
-  set duration($core.double v) { $_setDouble(1, v); }
+  set duration($core.double value) => $_setDouble(1, value);
   @$pb.TagNumber(2)
   $core.bool hasDuration() => $_has(1);
   @$pb.TagNumber(2)
-  void clearDuration() => clearField(2);
+  void clearDuration() => $_clearField(2);
 
   @$pb.TagNumber(3)
   $core.int get width => $_getIZ(2);
   @$pb.TagNumber(3)
-  set width($core.int v) { $_setUnsignedInt32(2, v); }
+  set width($core.int value) => $_setUnsignedInt32(2, value);
   @$pb.TagNumber(3)
   $core.bool hasWidth() => $_has(2);
   @$pb.TagNumber(3)
-  void clearWidth() => clearField(3);
+  void clearWidth() => $_clearField(3);
 
   @$pb.TagNumber(4)
   $core.int get height => $_getIZ(3);
   @$pb.TagNumber(4)
-  set height($core.int v) { $_setUnsignedInt32(3, v); }
+  set height($core.int value) => $_setUnsignedInt32(3, value);
   @$pb.TagNumber(4)
   $core.bool hasHeight() => $_has(3);
   @$pb.TagNumber(4)
-  void clearHeight() => clearField(4);
+  void clearHeight() => $_clearField(4);
 }
 
-
-const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter_avif_platform_interface/lib/models/frame.pbenum.dart
+++ b/flutter_avif_platform_interface/lib/models/frame.pbenum.dart
@@ -1,0 +1,11 @@
+// This is a generated file - do not edit.
+//
+// Generated from frame.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/flutter_avif_platform_interface/lib/models/frame.pbjson.dart
+++ b/flutter_avif_platform_interface/lib/models/frame.pbjson.dart
@@ -1,0 +1,32 @@
+// This is a generated file - do not edit.
+//
+// Generated from frame.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use frameDescriptor instead')
+const Frame$json = {
+  '1': 'Frame',
+  '2': [
+    {'1': 'data', '3': 1, '4': 1, '5': 12, '10': 'data'},
+    {'1': 'duration', '3': 2, '4': 1, '5': 1, '10': 'duration'},
+    {'1': 'width', '3': 3, '4': 1, '5': 13, '10': 'width'},
+    {'1': 'height', '3': 4, '4': 1, '5': 13, '10': 'height'},
+  ],
+};
+
+/// Descriptor for `Frame`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List frameDescriptor = $convert.base64Decode(
+    'CgVGcmFtZRISCgRkYXRhGAEgASgMUgRkYXRhEhoKCGR1cmF0aW9uGAIgASgBUghkdXJhdGlvbh'
+    'IUCgV3aWR0aBgDIAEoDVIFd2lkdGgSFgoGaGVpZ2h0GAQgASgNUgZoZWlnaHQ=');

--- a/flutter_avif_platform_interface/lib/models/key_request.pb.dart
+++ b/flutter_avif_platform_interface/lib/models/key_request.pb.dart
@@ -1,82 +1,88 @@
+// This is a generated file - do not edit.
 //
-//  Generated code. Do not modify.
-//  source: key_request.proto
-//
-// @dart = 2.12
+// Generated from key_request.proto.
+
+// @dart = 3.3
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
-// ignore_for_file: non_constant_identifier_names, prefer_final_fields
-// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
+
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
 class KeyRequest extends $pb.GeneratedMessage {
   factory KeyRequest({
     $core.String? key,
     $core.List<$core.int>? data,
   }) {
-    final $result = create();
-    if (key != null) {
-      $result.key = key;
-    }
-    if (data != null) {
-      $result.data = data;
-    }
-    return $result;
+    final result = create();
+    if (key != null) result.key = key;
+    if (data != null) result.data = data;
+    return result;
   }
-  KeyRequest._() : super();
-  factory KeyRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory KeyRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'KeyRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'models'), createEmptyInstance: create)
+  KeyRequest._();
+
+  factory KeyRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory KeyRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'KeyRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'models'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
-    ..hasRequiredFields = false
-  ;
+    ..a<$core.List<$core.int>>(
+        2, _omitFieldNames ? '' : 'data', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  KeyRequest clone() => KeyRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  KeyRequest copyWith(void Function(KeyRequest) updates) => super.copyWith((message) => updates(message as KeyRequest)) as KeyRequest;
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  KeyRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  KeyRequest copyWith(void Function(KeyRequest) updates) =>
+      super.copyWith((message) => updates(message as KeyRequest)) as KeyRequest;
 
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static KeyRequest create() => KeyRequest._();
+  @$core.override
   KeyRequest createEmptyInstance() => create();
-  static $pb.PbList<KeyRequest> createRepeated() => $pb.PbList<KeyRequest>();
   @$core.pragma('dart2js:noInline')
-  static KeyRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<KeyRequest>(create);
+  static KeyRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<KeyRequest>(create);
   static KeyRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) { $_setString(0, v); }
+  set key($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
-  void clearKey() => clearField(1);
+  void clearKey() => $_clearField(1);
 
   @$pb.TagNumber(2)
   $core.List<$core.int> get data => $_getN(1);
   @$pb.TagNumber(2)
-  set data($core.List<$core.int> v) { $_setBytes(1, v); }
+  set data($core.List<$core.int> value) => $_setBytes(1, value);
   @$pb.TagNumber(2)
   $core.bool hasData() => $_has(1);
   @$pb.TagNumber(2)
-  void clearData() => clearField(2);
+  void clearData() => $_clearField(2);
 }
 
-
-const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/flutter_avif_platform_interface/lib/models/key_request.pbenum.dart
+++ b/flutter_avif_platform_interface/lib/models/key_request.pbenum.dart
@@ -1,0 +1,11 @@
+// This is a generated file - do not edit.
+//
+// Generated from key_request.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/flutter_avif_platform_interface/lib/models/key_request.pbjson.dart
+++ b/flutter_avif_platform_interface/lib/models/key_request.pbjson.dart
@@ -1,0 +1,29 @@
+// This is a generated file - do not edit.
+//
+// Generated from key_request.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use keyRequestDescriptor instead')
+const KeyRequest$json = {
+  '1': 'KeyRequest',
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'data', '3': 2, '4': 1, '5': 12, '10': 'data'},
+  ],
+};
+
+/// Descriptor for `KeyRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List keyRequestDescriptor = $convert.base64Decode(
+    'CgpLZXlSZXF1ZXN0EhAKA2tleRgBIAEoCVIDa2V5EhIKBGRhdGEYAiABKAxSBGRhdGE=');

--- a/flutter_avif_platform_interface/pubspec.yaml
+++ b/flutter_avif_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   ffi: ^2.1.3
-  protobuf: ^3.1.0
+  protobuf: ^6.0.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
 - Upgrade protobuf dependency to `^6.0.0`.
 - Regenerate Dart models using `make dart` in the protobuf folder.
 
Closes: https://github.com/yekeskin/flutter_avif/issues/88